### PR TITLE
设置属性组件最低高度fix

### DIFF
--- a/src/app/pages/develop/comp-setting/comp-setting.component.scss
+++ b/src/app/pages/develop/comp-setting/comp-setting.component.scss
@@ -187,7 +187,7 @@
         cursor: pointer;
         max-height: 300px !important;
         &.showmore {
-            min-height: 100px !important; 
+            min-height: 60px !important; 
         }
         &.styles {
             max-height: 400px !important; 


### PR DESCRIPTION
之前设置的设置组件高度，导致整个设置组件高度超出页面